### PR TITLE
Ensure interior empty list items and some nbsp are not stripped away

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,44 @@
+PATH
+  remote: .
+  specs:
+    html2confluence (1.3.21)
+      nokogiri
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.1)
+    diff-lcs (1.3)
+    method_source (0.8.2)
+    mini_portile2 (2.1.0)
+    nokogiri (1.7.2)
+      mini_portile2 (~> 2.1.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
+    slop (3.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  html2confluence!
+  pry
+  rspec
+
+BUNDLED WITH
+   1.13.7

--- a/html2confluence.gemspec
+++ b/html2confluence.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
 
   s.require_path = 'lib'
   s.files        = Dir.glob("{lib,spec}/**/*") + %w(example.rb README.mdown)
-
+  
   s.add_dependency "nokogiri"
+  s.add_development_dependency "rspec"
 end

--- a/spec/combination_examples_spec.rb
+++ b/spec/combination_examples_spec.rb
@@ -1,144 +1,131 @@
-# encoding: utf-8
-$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
-require 'html2confluence'
+require_relative 'spec_helper'
 
 describe HTMLToConfluenceParser, "when running combination examples" do
   
   it "should match complex examples" do
-    html = <<-END
-<ol>
-	<li>a</li>
-	<li>numbered <b>item</b> that is <u>underlined</u>.</li>
-	<li>list</li>
-</ol>
-    END
+    html = <<~HTML
+      <ol>
+      	<li>a</li>
+      	<li>numbered <b>item</b> that is <u>underlined</u>.</li>
+      	<li>list</li>
+      </ol>
+    HTML
     
-    markup = <<-END
-# a 
-# numbered *item* that is +underlined+. 
-# list
-    END
-    
-    
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to include(markup.strip)
+    markup = <<~MARKUP
+      # a 
+      # numbered *item* that is +underlined+. 
+      # list
+    MARKUP
+
+    expect(html).to match_markup(markup)
   end
 
    it "should match nested lists" do
-    html = <<-END
-    <p>One line</p>
-    <ul>
-      <li>Nested</li>
-      <li>
-        <ol>
-          <li>bullets</li>
-          <li>go</li>
-          <li>here</li>
-          <li>
-            <ol>
-              <li>dfsdf</li>
-              <li>dsfs</li>
-            </ol>
-          </li>
-        </ol>
-      </li>
-      <li>Final bullet</li>
-    </ul>
+    html = <<~HTML
+      <p>One line</p>
+      <ul>
+        <li>Nested</li>
+        <li>
+          <ol>
+            <li>bullets</li>
+            <li>go</li>
+            <li>here</li>
+            <li>
+              <ol>
+                <li>dfsdf</li>
+                <li>dsfs</li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>Final bullet</li>
+      </ul>
 
-    <p>More stuff too</p>
+      <p>More stuff too</p>
 
-    <ul>
-      <li>In</li>
-      <li>
-        <ul>
-          <li>and</li>
-        </ul>
-      </li>
-      <li>out</li>
-      <li>
-        <ol>
-          <li>with numbers</li>
-          <li>
-            <ul>
-              <li>and sub-bullets</li>
-            </ul>
-          </li>
-        </ol>
-      </li>
-      <li>and back out</li>
-    </ul>
-    
-    <h1>With <u>nice</u> formatting.</h1>
-    END
+      <ul>
+        <li>In</li>
+        <li>
+          <ul>
+            <li>and</li>
+          </ul>
+        </li>
+        <li>out</li>
+        <li>
+          <ol>
+            <li>with numbers</li>
+            <li>
+              <ul>
+                <li>and sub-bullets</li>
+              </ul>
+            </li>
+          </ol>
+        </li>
+        <li>and back out</li>
+      </ul>
+      
+      <h1>With <u>nice</u> formatting.</h1>
+    HTML
 
-    markup = <<-END
-One line
+    markup = <<~MARKUP
+      One line
 
-* Nested 
-*# bullets 
-*# go 
-*# here 
-*## dfsdf 
-*## dsfs  
-* Final bullet 
+      * Nested 
+      *# bullets 
+      *# go 
+      *# here 
+      *## dfsdf 
+      *## dsfs  
+      * Final bullet 
 
-More stuff too
+      More stuff too
 
-* In 
-** and 
-* out 
-*# with numbers 
-*#* and sub-bullets  
-* and back out 
+      * In 
+      ** and 
+      * out 
+      *# with numbers 
+      *#* and sub-bullets  
+      * and back out 
 
-h1. With +nice+ formatting.
-    END
+      h1. With +nice+ formatting.
+    MARKUP
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to include(markup.strip)
+    expect(html).to match_markup(markup)
   end
   
   it "should match nested blockquotes" do
-    html = <<-END
-<blockquote><blockquote>content here</blockquote></blockquote>
-    END
+    html = <<~HTML
+      <blockquote><blockquote>content here</blockquote></blockquote>
+    HTML
 
-    markup = <<-END
-{quote}\nbq. content here\n{quote}
-    END
+    markup = <<~MARKUP
+      {quote}\nbq. content here\n{quote}
+    MARKUP
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to include(markup.strip)
+    expect(html).to match_markup(markup)
   end
   
   it "should handle empty paragraphs" do
-    html = <<-END
-    <p>Previous</p><p><br></p><p><b>Scenario 4a: Existing deletes their ID</b><br>
-    <b>Given</b> I am an existing user</p>
-    END
+    html = <<~HTML
+      <p>Previous</p><p><br></p><p><b>Scenario 4a: Existing deletes their ID</b><br>
+      <b>Given</b> I am an existing user</p>
+    HTML
 
     markup = "Previous\n\n*Scenario 4a: Existing deletes their ID*\n*Given* I am an existing user"
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to eq(markup)
+    expect(html).to match_markup(markup)
   end
   
   it "should handle empty bold sections" do
-    html = <<-END
-    <p>Previous line</p>
-    <p><b><br></b> <b>Scenario 4a: Existing deletes their ID</b><br>
-    <b>Given</b> I am an existing user</p>
-    END
+    html = <<~HTML
+      <p>Previous line</p>
+      <p><b><br></b> <b>Scenario 4a: Existing deletes their ID</b><br>
+      <b>Given</b> I am an existing user</p>
+    HTML
 
     markup = "Previous line\n\n*Scenario 4a: Existing deletes their ID*\n*Given* I am an existing user"
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to eq(markup)
+    expect(html).to match_markup(markup)
   end
   
   it "doesn't remove extra newlines" do
@@ -146,9 +133,7 @@ h1. With +nice+ formatting.
 
     markup = "*And* first line\n\n*second line*"
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to eq(markup)
+    expect(html).to match_markup(markup)
   end
   
   it "handles unclosed img tags" do
@@ -156,60 +141,47 @@ h1. With +nice+ formatting.
 
     markup = "!a source!"
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to eq(markup)
+    expect(html).to match_markup(markup)
   end
   
   it "handles wbr tags" do
     html = "<div>familiar with the XML<wbr>Http<wbr>Request Object</div>\n\n"
 
     markup = "familiar with the XMLHttpRequest Object"
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to eq(markup)
+    expect(html).to match_markup(markup)
     
   end
   
   it "should handle unclosed tags" do
-    html = <<-END
-    <p>Previous line</p>
-    <hr>
-    END
+    html = <<~HTML
+      <p>Previous line</p>
+      <hr>
+    HTML
 
     markup = "Previous line\n\n----"
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to eq(markup)
+    expect(html).to match_markup(markup)
   end
   
   it "should handle HTML comments" do
-    html = <<-END
-    <p><!--?rh-implicit_p?--><span style=\"font-style: italic;\">A</span></p>
-    END
+    html = <<~HTML
+      <p><!--?rh-implicit_p?--><span style=\"font-style: italic;\">A</span></p>
+    HTML
 
     markup = "A"
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to eq(markup)
+    expect(html).to match_markup(markup)
   end
   
   it "should handle CDATA elements" do
-    html = <<-END
-    <p>A</p>
-    <![CDATA[Comment inside cdata]]>
-    END
+    html = <<~HTML
+      <p>A</p>
+      <![CDATA[Comment inside cdata]]>
+    HTML
 
     markup = "A"
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to eq(markup)
+    expect(html).to match_markup(markup)
   end
   
 end
-
-
-

--- a/spec/complex_tables_spec.rb
+++ b/spec/complex_tables_spec.rb
@@ -1,90 +1,77 @@
-# encoding: utf-8
-$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
-require 'html2confluence'
+require_relative 'spec_helper'
 
 describe HTMLToConfluenceParser, "when running complex tables examples" do
   
    it "should handle table with newlines" do
-    html = <<-END
-    <table class="mce-item-table"><tbody><tr><td>As a...</td><td>I would like...</td><td>Because...</td></tr><tr><td><p>Student<br>or</p><p>Teacher</p></td><td>There to be more candy</td><td><p>Candy is:</p><ul><li>Delicious</li><li>Shiny</li><li>Good for my teeth</li></ul></td></tr></tbody></table>
-    END
+    html = <<~HTML
+      <table class="mce-item-table"><tbody><tr><td>As a...</td><td>I would like...</td><td>Because...</td></tr><tr><td><p>Student<br>or</p><p>Teacher</p></td><td>There to be more candy</td><td><p>Candy is:</p><ul><li>Delicious</li><li>Shiny</li><li>Good for my teeth</li></ul></td></tr></tbody></table>
+    HTML
 
-    markup = <<-END
-|As a...|I would like...|Because...|
-|Student
-or
-\\\\
-Teacher|There to be more candy|Candy is:
-\\\\
-* Delicious
-* Shiny
-* Good for my teeth|
-    END
+    markup = <<~MARKUP
+      |As a...|I would like...|Because...|
+      |Student
+      or
+      \\\\
+      Teacher|There to be more candy|Candy is:
+      \\\\
+      * Delicious
+      * Shiny
+      * Good for my teeth|
+    MARKUP
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to include(markup.strip)
+    expect(html).to match_markup(markup)
   end
   
    it "should handle table empty cells" do
-    html = <<-END
-    <table class="mce-item-table"><tbody><tr><td><p><br data-mce-bogus="1"></p></td><td>Empty</td><td><p><br data-mce-bogus="1"></p></td></tr></tbody></table>
-    END
+    html = <<~HTML
+      <table class="mce-item-table"><tbody><tr><td><p><br data-mce-bogus="1"></p></td><td>Empty</td><td><p><br data-mce-bogus="1"></p></td></tr></tbody></table>
+    HTML
 
-    markup = <<-END
-| |Empty| |
-    END
+    markup = <<~MARKUP
+      | |Empty| |
+    MARKUP
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to include(markup.strip)
+    expect(html).to match_markup(markup)
   end
   
    it "should handle pre in table empty cells" do
-    html = <<-END
-    <table><tbody><tr><td><pre>a</pre></td><td>d</td></tr><tr><td><pre>b</pre></td><td>c</td></tr></tbody></table>
-    END
+    html = <<~HTML
+      <table><tbody><tr><td><pre>a</pre></td><td>d</td></tr><tr><td><pre>b</pre></td><td>c</td></tr></tbody></table>
+    HTML
 
-    markup = <<-END
-|{noformat}
-a{noformat} |d |
-|{noformat}
-b{noformat} |c |
-    END
+    markup = <<~MARKUP
+      |{noformat}
+      a{noformat} |d |
+      |{noformat}
+      b{noformat} |c |
+    MARKUP
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to include(markup.strip)
+    expect(html).to match_markup(markup)
   end
   
    it "should handle pre in table" do
-    html = <<-END
-    <table><tbody>
-      <tr>
-        <td>A </td>
-        <td><tt>B</tt> </td>
-        <td>C </td>
-      </tr>
-      <tr>
-        <td>1 </td>
-        <td><pre>2</pre></td>
-        <td>3 </td>
-      </tr>
-    </tbody></table>
-    END
+    html = <<~HTML
+      <table><tbody>
+        <tr>
+          <td>A </td>
+          <td><tt>B</tt> </td>
+          <td>C </td>
+        </tr>
+        <tr>
+          <td>1 </td>
+          <td><pre>2</pre></td>
+          <td>3 </td>
+        </tr>
+      </tbody></table>
+    HTML
 
-    markup = <<-END
-|A |{{B}} |C | 
-|1 |{noformat}
-2{noformat} |3  |
-    END
+    markup = <<~MARKUP
+      |A |{{B}} |C | 
+      |1 |{noformat}
+      2{noformat} |3  |
+    MARKUP
 
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    expect(parser.to_wiki_markup.strip).to include(markup.strip)
+    expect(html).to match_markup(markup)
   end
   
 end
-
-
-

--- a/spec/html2confluence_spec.rb
+++ b/spec/html2confluence_spec.rb
@@ -1,139 +1,131 @@
-# encoding: utf-8
-$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
-require 'html2confluence'
-#require 'redcloth'
+require 'spec_helper'
 
 describe HTMLToConfluenceParser, "when converting html to textile" do
   
-  before :all do
-    html = <<-END
-    <div>
-      
-      Some text inside a div<br/>with two lines
-      <h1 class="story.title entry-title" id="post-312">
-      <img src="path_to_image.png" alt="Converting HTML to Textile with Ruby" />
-        <a href="http://jystewart.net/process/2007/11/converting-html-to-textile-with-ruby/" rel="bookmark">Converting HTML to Textile with Ruby</a>
-      </h1>
-      
-      <div class="note">A note</div><div class="note">Followed by another note</div>
-    
-      <p>
-        <span>23 November 2007</span> 
-        (<abbr class="updated" title="2007-11-23T19:51:54+00:00">7:51 pm</abbr>)
-      </p>
+  let :html do
+    <<~HTML
+      <div>
         
-      <p class='test'>
-        By <span class="author vcard fn">James Stewart</span> <br />filed under: 
-          <a href="http://jystewart.net/process/category/snippets/" title="View all posts in Snippets" rel="category tag">Snippets</a>
-          <br />tagged: <a href="http://jystewart.net/process/tag/content-management/" rel="tag">content management</a>,
-          <a href="http://jystewart.net/process/tag/conversion/" rel="tag">conversion</a>,
-          <a href="http://jystewart.net/process/tag/html/" rel="tag">html</a>,
-          <a href="http://jystewart.net/process/tag/python/" rel="tag">Python</a>,
-          <a href="http://jystewart.net/process/tag/ruby/" rel="tag">ruby</a>,
-          <a href="http://jystewart.net/process/tag/textile/" rel="tag">textile</a>
-      </p>
+        Some text inside a div<br/>with two lines
+        <h1 class="story.title entry-title" id="post-312">
+        <img src="path_to_image.png" alt="Converting HTML to Textile with Ruby" />
+          <a href="http://jystewart.net/process/2007/11/converting-html-to-textile-with-ruby/" rel="bookmark">Converting HTML to Textile with Ruby</a>
+        </h1>
+        
+        <div class="note">A note</div><div class="note">Followed by another note</div>
       
-      <p>test paragraph without id or class attributes</p>
-      
-      <p>test paragraph without closing tag</p>
-      
-      <p>Break not closed<br> at all</p>
-      
-      <li>test<strong> invalid </strong>list item 1</li>
-      <li>test invalid list item 2</li>
-      
-      <ol>
-        <li>test 1</li>
-        <li>test 2<br/>with a line break in the middle</li>
-        <li>test 3</li>
-        <li> <br/></li>
-      </ol>
-      
-      x&gt; y
-      
-      <blockquote>
-        <p>paragraph inside a blockquote</p>
-        <p>another paragraph inside a blockquote</p>
-      </blockquote>
-      
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-        Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure 
-        dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non 
-        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
-      <table cellpadding="3" style="color:red;" summary="a table with a caption">
-        <caption>table caption</caption>
-        <tr>
-          <th>heading 1</th>
-          <th>heading 2</th>
-        </tr>
-        <tr>
-          <td>value 1</td>
-          <td>value 2</td>
-        </tr>
-      </table>
-      
-      Hughes &amp; Hughes
-      
-      Something &amp; something else and <span rel="test">a useless span</span>
-      
-      Some text before a table<table summary="a table without a caption">
-        <tr>
-          <th>heading 1</th>
-          <th>heading 2</th>
-        </tr>
-        <tr>
-          <td>value 1</td>
-          <td>value 2</td>
-        </tr>
-      </table>
-      
-      <p>
-        <strong>Please apply online at:<br /></strong><a href="http://www.something.co.uk/careers">www.something.co.uk/careers</a></p>
-      
-      <p>test <strong><em>test emphasised bold text</em> </strong>test
-      An ordinal number - 1<sup>st </sup>
-      </p>
+        <p>
+          <span>23 November 2007</span> 
+          (<abbr class="updated" title="2007-11-23T19:51:54+00:00">7:51 pm</abbr>)
+        </p>
+          
+        <p class='test'>
+          By <span class="author vcard fn">James Stewart</span> <br />filed under: 
+            <a href="http://jystewart.net/process/category/snippets/" title="View all posts in Snippets" rel="category tag">Snippets</a>
+            <br />tagged: <a href="http://jystewart.net/process/tag/content-management/" rel="tag">content management</a>,
+            <a href="http://jystewart.net/process/tag/conversion/" rel="tag">conversion</a>,
+            <a href="http://jystewart.net/process/tag/html/" rel="tag">html</a>,
+            <a href="http://jystewart.net/process/tag/python/" rel="tag">Python</a>,
+            <a href="http://jystewart.net/process/tag/ruby/" rel="tag">ruby</a>,
+            <a href="http://jystewart.net/process/tag/textile/" rel="tag">textile</a>
+        </p>
+        
+        <p>test paragraph without id or class attributes</p>
+        
+        <p>test paragraph without closing tag</p>
+        
+        <p>Break not closed<br> at all</p>
+        
+        <li>test<strong> invalid </strong>list item 1</li>
+        <li>test invalid list item 2</li>
+        
+        <ol>
+          <li>test 1</li>
+          <li>test 2<br/>with a line break in the middle</li>
+          <li>test 3</li>
+          <li> <br/></li>
+        </ol>
+        
+        x&gt; y
+        
+        <blockquote>
+          <p>paragraph inside a blockquote</p>
+          <p>another paragraph inside a blockquote</p>
+        </blockquote>
+        
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+          Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure 
+          dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non 
+          proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+        <table cellpadding="3" style="color:red;" summary="a table with a caption">
+          <caption>table caption</caption>
+          <tr>
+            <th>heading 1</th>
+            <th>heading 2</th>
+          </tr>
+          <tr>
+            <td>value 1</td>
+            <td>value 2</td>
+          </tr>
+        </table>
+        
+        Hughes &amp; Hughes
+        
+        Something &amp; something else and <span rel="test">a useless span</span>
+        
+        Some text before a table<table summary="a table without a caption">
+          <tr>
+            <th>heading 1</th>
+            <th>heading 2</th>
+          </tr>
+          <tr>
+            <td>value 1</td>
+            <td>value 2</td>
+          </tr>
+        </table>
+        
+        <p>
+          <strong>Please apply online at:<br /></strong><a href="http://www.something.co.uk/careers">www.something.co.uk/careers</a></p>
+        
+        <p>test <strong><em>test emphasised bold text</em> </strong>test
+        An ordinal number - 1<sup>st </sup>
+        </p>
 
-      <div class="feedback">
-        Leave some feedback...<br/>
-        <script src="http://feeds.feedburner.com/~s/jystewart/iLiN?i=http://jystewart.net/process/2007/11/converting-html-to-textile-with-ruby/" type="text/javascript" charset="utf-8"></script>
+        <div class="feedback">
+          Leave some feedback...<br/>
+          <script src="http://feeds.feedburner.com/~s/jystewart/iLiN?i=http://jystewart.net/process/2007/11/converting-html-to-textile-with-ruby/" type="text/javascript" charset="utf-8"></script>
+        </div>
+        
+        <p>&nbsp;<br/></p>
+        <blockquote>&nbsp;<br/></blockquote>
+        <strong>more bold text</strong><strong><br /></strong>
+
+        <p>Some text with <u>underlining</u> is here.</p>
+
+        <p>Æïœü</p>
+
+        &copy; Copyright statement, let's see what happens to this&#8230; &euro; 100
+
+        An unknown named entity reference - &unknownref; 
+
+        <strike>strike 1</strike>
+        <del>strike 2</del>
+
+        # Not a list
+        * Not a list
+        - Not a list
+        *Not bold*
+        _Not a emph_
+        {Not curly}
+        |Not table
       </div>
-      
-      <p>&nbsp;<br/></p>
-      <blockquote>&nbsp;<br/></blockquote>
-      <strong>more bold text</strong><strong><br /></strong>
-
-      <p>Some text with <u>underlining</u> is here.</p>
-
-      <p>Æïœü</p>
-
-      &copy; Copyright statement, let's see what happens to this&#8230; &euro; 100
-
-      An unknown named entity reference - &unknownref; 
-
-      <strike>strike 1</strike>
-      <del>strike 2</del>
-
-      # Not a list
-      * Not a list
-      - Not a list
-      *Not bold*
-      _Not a emph_
-      {Not curly}
-      |Not table
-    </div>
-    END
-    parser = HTMLToConfluenceParser.new
-    parser.feed(html)
-    @textile = parser.to_wiki_markup
-    #puts @textile
-    #puts RedCloth.new(@textile).to_html
+    HTML
   end
 
   it "should convert heading tags" do
-    expect(@textile).to match(/^h1(\([^\)]+\))?\./)
+    expect(html).to match_markup(/^h1(\([^\)]+\))?\./)
   end
   
   it "should convert paragraph tags" do
@@ -141,95 +133,96 @@ describe HTMLToConfluenceParser, "when converting html to textile" do
   end
   
   it "should convert underline tags" do
-    expect(@textile).to include("text with +underlining+ is here")
+    expect(html).to include_markup("text with +underlining+ is here")
   end
   
   it "should not explicitly markup paragraphs unnecessarily" do
-    expect(@textile).to_not include("p. test paragraph without id or class attributes")
+    expect(html).not_to include_markup("p. test paragraph without id or class attributes")
   end
   
   it "should treat divs as block level elements, but ignore any attributes (effectively converting them to paragraphs)" do
-    expect(@textile).to include("\n\nA note\n\nFollowed by another note\n\n")
+    expect(html).to include_markup("\n\nA note\n\nFollowed by another note\n\n")
   end
   
   it "should not convert pointless spans to textile (i.e. without supported attributes)" do
-    expect(@textile).to_not include("%a useless span%")
+    expect(html).not_to include_markup("%a useless span%")
   end
 
-  it "should convert class and id attributes" do
-    # We don't convert classes. expect(@textile).to include("h1(story.title entry-title#post-312).")
-  end
+  # it "should convert class and id attributes" do
+  #   # We don't convert classes. 
+  #   expect(html).to include_markup("h1(story.title entry-title#post-312).")
+  # end
   
   it "should convert tables" do
-    expect(@textile).to include("\n\n||heading 1 ||heading 2 || \n|value 1 |value 2 | \n")
+    expect(html).to include_markup("\n\n||heading 1 ||heading 2 || \n|value 1 |value 2 | \n")
   end
   
   it "should convert tables with text immediately preceding the opening table tag" do
-    expect(@textile).to include("Some text before a table\n\n||heading 1 ||heading 2 || \n|value 1 |value 2 | \n")
+    expect(html).to include_markup("Some text before a table\n\n||heading 1 ||heading 2 || \n|value 1 |value 2 | \n")
   end
   
   it "should respect line breaks within block level elements" do
-    expect(@textile).to include("\n# test 1 \n# test 2\nwith a line break in the middle")
+    expect(html).to include_markup("\n# test 1 \n# test 2\nwith a line break in the middle")
   end
   
   it "should handle paragraphs nested within blockquote" do
-    expect(@textile).to include("{quote}\n\nparagraph inside a blockquote\n\nanother paragraph inside a blockquote\n\n{quote}")
+    expect(html).to include_markup("{quote}\n\nparagraph inside a blockquote\n\nanother paragraph inside a blockquote\n\n{quote}")
   end
   
   it "should retain leading and trailing whitespace within inline elements" do
-    expect(@textile).to include("test *invalid* list item 1")
+    expect(html).to include_markup("test *invalid* list item 1")
   end
   
   it "should respect trailing line break tags within other elements" do
-    expect(@textile).to include("*Please apply online at:*\n[www.something.co.uk/careers|http://www.something.co.uk/careers]")
+    expect(html).to include_markup("*Please apply online at:*\n[www.something.co.uk/careers|http://www.something.co.uk/careers]")
   end
   
   it "should handle nested inline elements" do
-    expect(@textile).to include(" *_test emphasised bold text_* test")
+    expect(html).to include_markup(" *_test emphasised bold text_* test")
   end
   
   it "should remove empty quicktags before returning" do
-    expect(@textile).to_not include("*more bold text* *\n*")
+    expect(html).not_to include_markup("*more bold text* *\n*")
   end  
   
   it "should remove unsupported elements (e.g. script)" do
-    expect(@textile).to_not include('script')
+    expect(html).not_to include_markup('script')
   end
   
   it "should remove unsupported attributes (i.e. everything but class and id)" do
-    expect(@textile).to_not include('summary')
-    expect(@textile).to_not include('a table with a caption')
-    expect(@textile).to_not include('style')
-    expect(@textile).to_not include('color:red;')
+    expect(html).not_to include_markup('summary')
+    expect(html).not_to include_markup('a table with a caption')
+    expect(html).not_to include_markup('style')
+    expect(html).not_to include_markup('color:red;')
   end
   
   it "should clean up multiple blank lines created by tolerant parsing before returning" do
-    expect(@textile).to_not match(/(\n\n\s*){2,}/)
+    expect(html).not_to match_markup(/(\n\n\s*){2,}/)
   end
   
   it "should keep entity references" do
-    expect(@textile).to include("&copy;")
+    expect(html).to include_markup("&copy;")
   end
   
   it "should output unknown named entity references" do
-    expect(@textile).to include("&unknownref;")
+    expect(html).to include_markup("&unknownref;")
   end  
   
   it "should convert numerical entity references to a utf-8 character" do
-    expect(@textile).to include("…")
+    expect(html).to include_markup("…")
   end
 
   it "should ignore entities that are already converted" do
-    expect(@textile).to include("Æïœü")
+    expect(html).to include_markup("Æïœü")
   end
   
   it "should ignore ampersands that are not part of an entity reference" do
-    expect(@textile).to include("Hughes & Hughes")
+    expect(html).to include_markup("Hughes & Hughes")
   end
   
   it "should retain whitespace surrounding entity references" do
-    expect(@textile).to include("… &euro; 100")
-    expect(@textile).to include("Something & something")
+    expect(html).to include_markup("… &euro; 100")
+    expect(html).to include_markup("Something & something")
   end
   
   it "should escape special characters" do
@@ -237,19 +230,18 @@ describe HTMLToConfluenceParser, "when converting html to textile" do
     # characters that would otherwise be mistaken for markup. It should not
     # escape every instance of these characters.
     pending 'only escape correct characters'
-    expect(@textile).to include("\\# Not a list")
-    expect(@textile).to include("\\* Not a list")
-    expect(@textile).to include("\\- Not a list")
-    expect(@textile).to include("\\*Not bold\\*")
-    expect(@textile).to include("\\_Not a emph\\_")
-    expect(@textile).to include("\\{Not curly\\}")
-    expect(@textile).to include("\\|Not table")
+    expect(html).to include_markup("\\# Not a list")
+    expect(html).to include_markup("\\* Not a list")
+    expect(html).to include_markup("\\- Not a list")
+    expect(html).to include_markup("\\*Not bold\\*")
+    expect(html).to include_markup("\\_Not a emph\\_")
+    expect(html).to include_markup("\\{Not curly\\}")
+    expect(html).to include_markup("\\|Not table")
   end
   
   it "should support strikethrough" do
-    expect(@textile).to include("-strike 1-")
-    expect(@textile).to include("-strike 2-")
+    expect(html).to include_markup("-strike 1-")
+    expect(html).to include_markup("-strike 2-")
   end
-  
   
 end

--- a/spec/jira_examples_spec.rb
+++ b/spec/jira_examples_spec.rb
@@ -1,219 +1,217 @@
-# encoding: utf-8
-$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
-require 'html2confluence'
+require_relative 'spec_helper'
 
 describe HTMLToConfluenceParser, "when running JIRA examples" do
   
   before :all do
-    html = <<-END
-<h1><a name="Biggestheading"></a>Biggest heading</h1>
-<h2><a name="Biggerheading"></a>Bigger heading</h2>
-<h3><a name="Bigheading"></a>Big heading</h3>
-<h4><a name="Normalheading"></a>Normal heading</h4>
-<h5><a name="Smallheading"></a>Small heading</h5>
-<h6><a name="Smallestheading"></a>Smallest heading</h6>
+    html = <<~HTML
+      <h1><a name="Biggestheading"></a>Biggest heading</h1>
+      <h2><a name="Biggerheading"></a>Bigger heading</h2>
+      <h3><a name="Bigheading"></a>Big heading</h3>
+      <h4><a name="Normalheading"></a>Normal heading</h4>
+      <h5><a name="Smallheading"></a>Small heading</h5>
+      <h6><a name="Smallestheading"></a>Smallest heading</h6>
 
-<p><b>strong</b><br/>
-<em>emphasis</em><br/>
-<cite>citation</cite><br/>
-<del>deleted</del><br/>
-<ins>inserted</ins><br/>
-<sup>superscript</sup><br/>
-<sub>subscript</sub><br/>
-<tt>monospaced</tt></p>
-<blockquote>Some block quoted text</blockquote>
+      <p><b>strong</b><br/>
+      <em>emphasis</em><br/>
+      <cite>citation</cite><br/>
+      <del>deleted</del><br/>
+      <ins>inserted</ins><br/>
+      <sup>superscript</sup><br/>
+      <sub>subscript</sub><br/>
+      <tt>monospaced</tt></p>
+      <blockquote>Some block quoted text</blockquote>
 
-<blockquote>
-<p> here is quotable<br/>
- content to be quoted</p></blockquote>
+      <blockquote>
+      <p> here is quotable<br/>
+       content to be quoted</p></blockquote>
 
-<p><font color="red"><br/>
-    look ma, red text!</font></p>
+      <p><font color="red"><br/>
+          look ma, red text!</font></p>
 
-<p>a<br class="atl-forced-newline" />b</p>
+      <p>a<br class="atl-forced-newline" />b</p>
 
-<p>a<br/>
-b</p>
+      <p>a<br/>
+      b</p>
 
-<hr />
+      <hr />
 
-<p>a &#8211; b<br/>
-a &#8212; b</p>
+      <p>a &#8211; b<br/>
+      a &#8212; b</p>
 
-<p><a href="#anchor">anchor</a></p>
+      <p><a href="#anchor">anchor</a></p>
 
-<p><a href="http://jira.atlassian.com" class="external-link" rel="nofollow">http://jira.atlassian.com</a><br/>
-<a href="http://atlassian.com" class="external-link" rel="nofollow">Atlassian</a></p>
+      <p><a href="http://jira.atlassian.com" class="external-link" rel="nofollow">http://jira.atlassian.com</a><br/>
+      <a href="http://atlassian.com" class="external-link" rel="nofollow">Atlassian</a></p>
 
-<p><a href="file:///c:/temp/foo.txt" class="external-link" rel="nofollow">file:///c:/temp/foo.txt</a></p>
+      <p><a href="file:///c:/temp/foo.txt" class="external-link" rel="nofollow">file:///c:/temp/foo.txt</a></p>
 
-<p><a name="anchorname"></a></p>
+      <p><a name="anchorname"></a></p>
 
-<ul>
-  <li>some</li>
-  <li>bullet
-  <ul>
-    <li>indented</li>
-    <li>bullets</li>
-  </ul>
-  </li>
-  <li>points</li>
-</ul>
-
-
-<ul class="alternate" type="square">
-  <li>different</li>
-  <li>bullet</li>
-  <li>types</li>
-</ul>
+      <ul>
+        <li>some</li>
+        <li>bullet
+        <ul>
+          <li>indented</li>
+          <li>bullets</li>
+        </ul>
+        </li>
+        <li>points</li>
+      </ul>
 
 
-<ol>
-  <li>a</li>
-  <li>numbered</li>
-  <li>list</li>
-</ol>
+      <ul class="alternate" type="square">
+        <li>different</li>
+        <li>bullet</li>
+        <li>types</li>
+      </ul>
 
 
-<ol>
-  <li>a</li>
-  <li>numbered
-  <ul>
-    <li>with</li>
-    <li>nested</li>
-    <li>bullet</li>
-  </ul>
-  </li>
-  <li>list</li>
-</ol>
+      <ol>
+        <li>a</li>
+        <li>numbered</li>
+        <li>list</li>
+      </ol>
 
 
-<ul>
-  <li>a</li>
-  <li>bulleted
-  <ol>
-    <li>with</li>
-    <li>nested</li>
-    <li>numbered</li>
-  </ol>
-  </li>
-  <li>list</li>
-</ul>
+      <ol>
+        <li>a</li>
+        <li>numbered
+        <ul>
+          <li>with</li>
+          <li>nested</li>
+          <li>bullet</li>
+        </ul>
+        </li>
+        <li>list</li>
+      </ol>
 
 
-<table class='confluenceTable'><tbody>
-<tr>
-<th class='confluenceTh'>heading 1</th>
-<th class='confluenceTh'>heading 2</th>
-<th class='confluenceTh'>heading 3</th>
-</tr>
-<tr>
-<td class='confluenceTd'>col A1</td>
-<td class='confluenceTd'>col A2</td>
-<td class='confluenceTd'>col A3</td>
-</tr>
-<tr>
-<td class='confluenceTd'>col B1</td>
-<td class='confluenceTd'>col B2</td>
-<td class='confluenceTd'>col B3</td>
-</tr>
-</tbody></table>
+      <ul>
+        <li>a</li>
+        <li>bulleted
+        <ol>
+          <li>with</li>
+          <li>nested</li>
+          <li>numbered</li>
+        </ol>
+        </li>
+        <li>list</li>
+      </ul>
 
-<img src="https://somdomain.net/images/icons/emoticons/smile.gif">
-<img src="https://somdomain.net/images/icons/emoticons/warning.gif">
-<img src="/images/icons/emoticons/lightbulb.gif">
-<img src="https://bigaha.atlassian.net/images/icons/emoticons/check.png" />
 
-<div class="preformatted panel" style="border-width: 1px;"><div class="preformattedContent panelContent">
-<pre>preformatted piece of text
- so *no* further _formatting_ is done here
-</pre>
-</div></div>
-    END
-    
-    markup = <<-END
-  h1. Biggest heading
-h2. Bigger heading
-h3. Big heading
-h4. Normal heading
-h5. Small heading
-h6. Smallest heading
+      <table class='confluenceTable'><tbody>
+      <tr>
+      <th class='confluenceTh'>heading 1</th>
+      <th class='confluenceTh'>heading 2</th>
+      <th class='confluenceTh'>heading 3</th>
+      </tr>
+      <tr>
+      <td class='confluenceTd'>col A1</td>
+      <td class='confluenceTd'>col A2</td>
+      <td class='confluenceTd'>col A3</td>
+      </tr>
+      <tr>
+      <td class='confluenceTd'>col B1</td>
+      <td class='confluenceTd'>col B2</td>
+      <td class='confluenceTd'>col B3</td>
+      </tr>
+      </tbody></table>
 
-*strong*
-_emphasis_
-??citation??
--deleted-
-+inserted+
-^superscript^
-~subscript~
-{{monospaced}}
-bq. Some block quoted text
+      <img src="https://somdomain.net/images/icons/emoticons/smile.gif">
+      <img src="https://somdomain.net/images/icons/emoticons/warning.gif">
+      <img src="/images/icons/emoticons/lightbulb.gif">
+      <img src="https://bigaha.atlassian.net/images/icons/emoticons/check.png" />
 
-{quote}
- here is quotable
- content to be quoted
-{quote}
+      <div class="preformatted panel" style="border-width: 1px;"><div class="preformattedContent panelContent">
+      <pre>preformatted piece of text
+       so *no* further _formatting_ is done here
+      </pre>
+      </div></div>
+    HTML
+          
+    markup = <<~MARKUP
+      h1. Biggest heading
+      h2. Bigger heading
+      h3. Big heading
+      h4. Normal heading
+      h5. Small heading
+      h6. Smallest heading
 
-{color:red}
-    look ma, red text!
-{color}
+      *strong*
+      _emphasis_
+      ??citation??
+      -deleted-
+      +inserted+
+      ^superscript^
+      ~subscript~
+      {{monospaced}}
+      bq. Some block quoted text
 
-a\\b
+      {quote}
+       here is quotable
+       content to be quoted
+      {quote}
 
-a
-b
+      {color:red}
+          look ma, red text!
+      {color}
 
-----
+      a\\b
 
-a -- b
-a --- b
+      a
+      b
 
-[#anchor]
+      ----
 
-[http://jira.atlassian.com]
-[Atlassian|http://atlassian.com]
+      a -- b
+      a --- b
 
-[file:///c:/temp/foo.txt]
+      [#anchor]
 
-{anchor:anchorname}
+      [http://jira.atlassian.com]
+      [Atlassian|http://atlassian.com]
 
-* some
-* bullet
-** indented
-** bullets
-* points
+      [file:///c:/temp/foo.txt]
 
-- different
-- bullet
-- types
+      {anchor:anchorname}
 
-# a
-# numbered
-# list
+      * some
+      * bullet
+      ** indented
+      ** bullets
+      * points
 
-# a
-# numbered
-#* with
-#* nested
-#* bullet
-# list
+      - different
+      - bullet
+      - types
 
-* a
-* bulleted
-*# with
-*# nested
-*# numbered
-* list
+      # a
+      # numbered
+      # list
 
-||heading 1||heading 2||heading 3||
-|col A1|col A2|col A3|
-|col B1|col B2|col B3|
+      # a
+      # numbered
+      #* with
+      #* nested
+      #* bullet
+      # list
 
-{noformat}
-preformatted piece of text
- so *no* further _formatting_ is done here
-{noformat}
-    END
+      * a
+      * bulleted
+      *# with
+      *# nested
+      *# numbered
+      * list
+
+      ||heading 1||heading 2||heading 3||
+      |col A1|col A2|col A3|
+      |col B1|col B2|col B3|
+
+      {noformat}
+      preformatted piece of text
+       so *no* further _formatting_ is done here
+      {noformat}
+    MARKUP
     
     
     parser = HTMLToConfluenceParser.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,88 @@
+$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
+require 'html2confluence'
+
+require 'rspec'
+
+RSpec.configure do |config|
+  config.color = true
+  config.tty = true
+  config.formatter = :documentation
+end
+
+require 'rspec/expectations'
+
+module MarkupHelpers
+  module_function
+  
+  def html_to_markup(html)
+    parser = HTMLToConfluenceParser.new
+    parser.feed(html)
+    parser.to_wiki_markup
+  end
+  
+  def indent(markup)
+    if markup.kind_of? String
+      markup.lines.map{|l| "  #{l}"}.join
+    else
+      "  #{markup.inspect}"
+    end
+  end
+  
+end
+
+RSpec::Matchers.define :match_markup do |markup|
+  include MarkupHelpers
+  
+  diffable
+  
+  match do |html|
+    @html = html
+    @actual = html_to_markup(html).strip
+    @markup = markup
+    case markup
+    when String
+      values_match? @markup.strip, @actual
+    when Regexp
+      !!markup.match(@actual)
+    end
+  end
+  
+  failure_message do |html|
+    <<~ERR
+    expected that the parsed HTML:
+    #{indent @html}
+    
+    would produce markup matching:
+    #{indent @markup}
+    
+    instead, the parser produced:
+    #{indent @actual}
+    ERR
+  end
+end
+
+RSpec::Matchers.define :include_markup do |markup|
+  include MarkupHelpers
+  
+  diffable
+  
+  match do |html|
+    @html = html
+    @actual = html_to_markup(html).strip
+    @markup = markup.strip
+    @actual.include? @markup
+  end
+  
+  failure_message do |html|
+    <<~ERR
+    expected that the parsed HTML:
+    #{indent @html}
+    
+    would include markup:
+    #{indent @markup}
+    
+    instead, the parser produced:
+    #{indent @actual}
+    ERR
+  end
+end

--- a/spec/tinymce_examples_spec.rb
+++ b/spec/tinymce_examples_spec.rb
@@ -1,0 +1,313 @@
+require_relative 'spec_helper'
+
+describe HTMLToConfluenceParser, "when consuming TinyMCE generated HTML" do
+
+  context "edge case with nested formats with spans and &nbsp;" do
+
+    it "should handle nested formatting" do
+      html = <<~HTML
+        test<i>test<b>test</b></i>
+      HTML
+
+      markup = <<~MARKUP
+        test_test*test*_
+      MARKUP
+
+      expect(html).to match_markup(markup)
+    end
+
+    it "should handle arbitrary spans" do
+      html = <<~HTML
+        test<span>test<span>test</span></span>
+      HTML
+
+      markup = <<~MARKUP
+        testtesttest
+      MARKUP
+
+      expect(html).to match_markup(markup)
+    end
+
+    it "should handle arbitrary %nbsp;" do
+      html = <<~HTML
+        test&nbsp;test&nbsp;test
+      HTML
+
+      markup = <<~MARKUP
+        test test test
+      MARKUP
+
+      expect(html).to match_markup(markup)
+    end
+
+    it "should handle trailing %nbsp; inside formats" do
+      html = <<~HTML
+        <b>test&nbsp;</b>
+      HTML
+
+      markup = <<~MARKUP
+        *test *
+      MARKUP
+
+      expect(html).to match_markup(markup)
+    end
+
+    it "should handle format-wrapping spans" do
+      html = <<~HTML
+        <span><b>test</b></span>
+      HTML
+
+      markup = <<~MARKUP
+        *test*
+      MARKUP
+
+      expect(html).to match_markup(markup)
+    end
+
+    it "should handle consecutive format-delineated spaces" do
+      html = <<~HTML
+        <b>test&nbsp;</b> test
+      HTML
+
+      markup = <<~MARKUP
+        *test * test
+      MARKUP
+
+      expect(html).to match_markup(markup)
+    end
+
+    it "should handle all these things at once" do
+      html = <<~HTML
+        test&nbsp;<span><i>test&nbsp;<span><b>test</b></span></i></span>
+      HTML
+
+      markup = <<~MARKUP
+        test _test *test*_
+      MARKUP
+
+      expect(html).to match_markup(markup)
+    end
+
+  end
+
+  context "with empty li's" do
+
+    it "should preserve leading empty li's" do
+      html = <<~HTML
+        <ul>
+          <li></li>
+          <li>test</li>
+          <li>test</li>
+        </ul>
+      HTML
+
+      markup = "*  \n* test \n* test "
+
+      expect(html).to match_markup(markup)
+    end
+
+
+    it "should preserve inner empty li's" do
+      html = <<~HTML
+        <ul>
+          <li>test</li>
+          <li></li>
+          <li>test</li>
+        </ul>
+      HTML
+
+      markup = "* test \n* \n* test "
+
+      expect(html).to match_markup(markup)
+    end
+
+
+    it "should preserve trailing empty li's" do
+      html = <<~HTML
+        <ul>
+          <li>test</li>
+          <li>test</li>
+          <li></li>
+        </ul>
+      HTML
+
+      markup = "* test \n* test \n* "
+
+      expect(html).to match_markup(markup)
+    end
+
+  end
+
+  context "formatting within tables" do
+
+    it "should normalize spaces around table items to only contain one trailing space" do
+      html = <<~HTML
+      <table><tbody>
+        <tr>
+          <th> Header</th>
+        </tr>
+        <tr>
+          <td>text   </td>
+        </tr>
+      </tbody></table>
+      HTML
+
+      markup = <<~HTML
+      ||Header ||
+      |text |
+      HTML
+
+      expect(html).to match_markup(markup)
+    end
+
+    it "should handle formatting" do
+      html = <<~HTML
+      <table><tbody>
+        <tr>
+          <th>Header</th>
+        </tr>
+        <tr>
+          <td><b>bold</b></td>
+        </tr>
+      </tbody></table>
+      HTML
+
+      markup = <<~HTML
+      ||Header ||
+      |*bold* |
+      HTML
+
+      expect(html).to match_markup(markup)
+    end
+
+    it "should handle lists" do
+      html = <<~HTML
+        <table>
+          <tr>
+            <th>Header</th>
+          </tr>
+          <tr>
+            <td>
+              <ul>
+                <li>test</li>
+                <li>test</li>
+              </ul>
+            </td>
+          </tr>
+        </table>
+      HTML
+
+      markup = <<~HTML
+      ||Header ||
+      |* test
+      * test |
+      HTML
+
+      expect(html).to match_markup(markup)
+    end
+
+    it "should handle empty cells" do
+      html = <<~HTML
+      <table><tbody>
+        <tr>
+          <th>Header</th>
+        </tr>
+        <tr>
+          <td></td>
+        </tr>
+      </tbody></table>
+      HTML
+
+      markup = <<~HTML
+      ||Header ||
+      | |
+      HTML
+
+      expect(html).to match_markup(markup)
+
+      html = <<~HTML
+      <table><tbody>
+        <tr>
+          <th>Header</th>
+          <th>Header</th>
+        </tr>
+        <tr>
+          <td>text</td>
+          <td></td>
+        </tr>
+      </tbody></table>
+      HTML
+
+      markup = <<~HTML
+      ||Header ||Header ||
+      |text | |
+      HTML
+
+      expect(html).to match_markup(markup)
+
+      html = <<~HTML
+      <table><tbody>
+        <tr>
+          <th>Header</th>
+          <th>Header</th>
+        </tr>
+        <tr>
+          <td>text</td>
+          <td></td>
+        </tr>
+      </tbody></table>
+      HTML
+
+      markup = <<~HTML
+      ||Header ||Header ||
+      |text | |
+      HTML
+
+      expect(html).to match_markup(markup)
+
+      html = <<~HTML
+      <table><tbody>
+        <tr>
+          <th>Header</th>
+          <th>Header</th>
+        </tr>
+        <tr>
+          <td></td>
+          <td>text</td>
+        </tr>
+      </tbody></table>
+      HTML
+
+      markup = <<~HTML
+      ||Header ||Header ||
+      | |text |
+      HTML
+
+      expect(html).to match_markup(markup)
+
+      html = <<~HTML
+      <table><tbody>
+        <tr>
+          <th>Header</th>
+          <th>Header</th>
+          <th>Header</th>
+        </tr>
+        <tr>
+          <td>text</td>
+          <td></td>
+          <td>text</td>
+        </tr>
+      </tbody></table>
+      HTML
+
+      markup = <<~HTML
+      ||Header ||Header ||Header ||
+      |text | |text |
+      HTML
+
+      expect(html).to match_markup(markup)
+    end
+
+  end
+
+end


### PR DESCRIPTION
The first commit here adds a Gemfile and rspec to the gemspec for easier development, and reworks the test suite with some custom rspec helpers to remove boilerplate, and makes use of the indentation-aware `<<~HEREDOC` to add some consistency.

It changes neither library code nor spec code.

The second commit contains specs written when trying to repro and debug small errors observed by customers during editing experiences with TinyMCE, hence the name `tinymce_examples_spec`.

- interior empty `<li>`s are no longer stripped
- certain `&nbsp;` are no longer stripped away
- adds some tests for extra percents in output from span quicktags fixed by jeremy previously
- adds some tests for probing around issues with whitespace in tables