### PR TITLE
App 6796 parsing block quotes

### DIFF
--- a/lib/html2confluence.rb
+++ b/lib/html2confluence.rb
@@ -17,13 +17,13 @@ require 'nokogiri' # For validating html from our editor
 #   parser.feed(input_html)
 #   puts parser.to_wiki_markup
 class HTMLToConfluenceParser
-  
+
   attr_accessor :result
   attr_accessor :data_stack
   attr_accessor :a_href
   attr_accessor :a_title
   attr_accessor :list_stack
-  
+
   def initialize(verbose=nil)
     @output = String.new
     @stack = []
@@ -34,24 +34,24 @@ class HTMLToConfluenceParser
     self.data_stack = []
     self.list_stack = []
   end
-  
+
   # Normalise space in the same manner as HTML. Any substring of multiple
   # whitespace characters will be replaced with a single space char.
   def normalise_space(s)
     return s if @preserveWhitespace
     s.to_s.gsub(/\s+/x, ' ')
   end
-  
+
   # Escape any special characters.
   def escape_special_characters(s)
     return s
-    # Escaping is disabled now since it caused more problems that not having 
+    # Escaping is disabled now since it caused more problems that not having
     # it. The insertion of unecessary escaping was annoying for JIRA users.
     s.to_s.gsub(/[*#+\-_{}|]/) do |s|
       "\\#{s}"
     end
   end
-  
+
   def make_block_start_pair(tag, attributes)
     if tag == 'p'
       # don't markup paragraphs explicitly unless necessary (i.e. there are id or class attributes)
@@ -61,12 +61,12 @@ class HTMLToConfluenceParser
     end
     start_capture(tag)
   end
-  
+
   def make_block_end_pair
     stop_capture_and_write
     write("\n\n")
   end
-  
+
   def make_quicktag_start_pair(tag, wrapchar, attributes)
     @skip_quicktag = ( tag == 'span')
     start_capture(tag)
@@ -74,31 +74,31 @@ class HTMLToConfluenceParser
 
   def make_quicktag_end_pair(wrapchar)
     content = stop_capture
-    
-    # Don't make quicktags with empty content. 
+
+    # Don't make quicktags with empty content.
     if content.join("").strip.empty?
       write(content)
       return
     end
-    
+
     unless @skip_quicktag
       unless in_nested_quicktag?
-        #write([" "]) 
+        #write([" "])
       end
       write(["#{wrapchar}"])
     end
     write(content.collect(&:strip))
     write([wrapchar]) unless @skip_quicktag
     unless in_nested_quicktag?
-      #write([" "]) 
+      #write([" "])
     end
   end
-  
+
   def in_nested_quicktag?
     @quicktags ||= QUICKTAGS.keys
     @stack.size > 1 && @quicktags.include?(@stack[@stack.size-1]) && @quicktags.include?(@stack[@stack.size-2])
   end
-  
+
   def write(d)
     @last_write = Array(d).join("")
     if self.data_stack.size < 2
@@ -107,15 +107,15 @@ class HTMLToConfluenceParser
       self.data_stack[-1] += Array(d)
     end
   end
-          
+
   def start_capture(tag)
     self.data_stack.push([])
   end
-  
+
   def stop_capture
     self.data_stack.pop
   end
-  
+
   def stop_capture_and_write
     self.write(self.data_stack.pop)
   end
@@ -129,7 +129,7 @@ class HTMLToConfluenceParser
       if @last_write[-1] =~ /\s/
         data = data.lstrip # Collapse whitespace if the previous character was whitespace.
       end
-        
+
       write(data)
     end
   end
@@ -138,7 +138,7 @@ class HTMLToConfluenceParser
     define_method "start_h#{num}" do |attributes|
       make_block_start_pair("h#{num}", attributes)
     end
-    
+
     define_method "end_h#{num}" do
       make_block_end_pair
     end
@@ -146,47 +146,47 @@ class HTMLToConfluenceParser
 
   PAIRS = { 'bq' => 'bq', 'p' => 'p' }
   QUICKTAGS = { 'b' => '*', 'strong' => '*', 'del' => '-',  'strike' => '-',
-    'i' => '_', 'ins' => '+', 'u' => '+', 'em' => '_', 'cite' => '??', 
+    'i' => '_', 'ins' => '+', 'u' => '+', 'em' => '_', 'cite' => '??',
     'sup' => '^', 'sub' => '~'}
-  
+
   PAIRS.each do |key, value|
     define_method "start_#{key}" do |attributes|
       make_block_start_pair(value, attributes)
     end
-    
+
     define_method "end_#{key}" do
       make_block_end_pair
     end
   end
-  
+
   QUICKTAGS.each do |key, value|
     define_method "start_#{key}" do |attributes|
       make_quicktag_start_pair(key, value, attributes)
     end
-    
+
     define_method "end_#{key}" do
       make_quicktag_end_pair(value)
     end
   end
-  
+
   def start_div(attrs)
     write("\n\n")
     start_capture("div")
   end
-  
+
   def end_div
     stop_capture_and_write
     write("\n\n")
-  end  
-  
+  end
+
   def start_tt(attrs)
     write("{{")
   end
-  
+
   def end_tt
     write("}}")
   end
-  
+
   def start_ol(attrs)
     self.list_stack.push :ol
   end
@@ -212,15 +212,15 @@ class HTMLToConfluenceParser
       write("\n")
     end
   end
-  
+
   def start_li(attrs)
     write("\n")
-    write(self.list_stack.collect {|s| 
+    write(self.list_stack.collect {|s|
         case s
         when :ol then "#"
         when :ul then "*"
-        when :ul_square then "-" 
-        end 
+        when :ul_square then "-"
+        end
       }.join(""))
     write(" ")
     start_capture("li")
@@ -262,12 +262,12 @@ class HTMLToConfluenceParser
       self.a_href = self.a_title = false
     end
   end
-  
+
   def start_font(attrs)
     color = attrs['color']
     write("{color:#{color}}")
   end
-  
+
   def end_font
     write("{color}")
   end
@@ -275,25 +275,25 @@ class HTMLToConfluenceParser
   def start_img(attrs)
     write([" !", attrs["src"], "! "])
   end
-  
+
   def end_img
   end
 
   def start_table(attrs)
    write("\n\n")
  end
- 
+
   def end_table
    write("\n\n")
-  end 
+  end
 
   def start_caption(attrs)
    write("\n")
  end
- 
+
   def end_caption
    write("\n")
-  end 
+  end
 
   def start_tr(attrs)
     write("\n")
@@ -306,7 +306,7 @@ class HTMLToConfluenceParser
       write("|")
     end
   end
-  
+
   def start_th(attrs)
     write("||")
     start_capture("th")
@@ -316,7 +316,7 @@ class HTMLToConfluenceParser
   def end_th
     s = stop_capture
     write(cleanup_table_cell(s))
-  end  
+  end
 
   def start_td(attrs)
     write("|")
@@ -328,7 +328,7 @@ class HTMLToConfluenceParser
     s = stop_capture
     write(cleanup_table_cell(s))
   end
-  
+
   def cleanup_table_cell(s)
     clean_content = (s || []).join("").strip.gsub(/\n{2,}/, "\n" + '\\\\\\' + "\n")
     # Don't allow a completely empty cell because that will look like a header.
@@ -339,29 +339,19 @@ class HTMLToConfluenceParser
   def start_br(attrs)
     write("\n")
   end
-  
+
   def start_hr(attrs)
     write("----")
   end
-  
+
   def start_blockquote(attrs)
+    write("\n{quote}\n")
     start_capture("blockquote")
   end
 
   def end_blockquote
-    s = stop_capture
-    contains_newline = s.detect do |phrase|
-      phrase =~ /\n/ or phrase == "bq. "
-    end
-    
-    if contains_newline
-      write("\n{quote}\n")
-      write(s)
-      write("\n{quote}")
-    else
-      write("bq. ")
-      write(s)
-    end
+    stop_capture_and_write
+    write("\n{quote}\n")
   end
 
   def start_code(attrs)
@@ -374,7 +364,7 @@ class HTMLToConfluenceParser
     write("{code}")
     @preserveWhitespace = false
   end
-  
+
   def start_pre(attrs)
     @preserveWhitespace = true
     write("{noformat}\n")
@@ -385,7 +375,7 @@ class HTMLToConfluenceParser
     write("{noformat}")
     @preserveWhitespace = false
   end
-  
+
   def preprocess(data)
     # clean up leading and trailing spaces within phrase modifier tags
     quicktags_for_re = QUICKTAGS.keys.uniq.join('|')
@@ -402,19 +392,19 @@ class HTMLToConfluenceParser
     # replace special entities.
     data.gsub!(/&(mdash|#8212);/,'---')
     data.gsub!(/&(ndash|#8211);/,'--')
-    
+
     # remove empty blockquotes and list items (other empty elements are easy enough to deal with)
     data.gsub!(/<blockquote>\s*(<br[^>]*>)?\s*<\/blockquote>/x,' ')
-    
+
     # Fix unclosed <br>
     data.gsub!(/<br[^>]*>/, "<br/>")
 
     # Remove <wbr>
     data.gsub!(/<wbr[^>]*>/, "")
-    
+
     # Fix unclosed <hr>
     data.gsub!(/<hr[^>]*>/, "<hr/>")
-    
+
     # Fix unclosed <img>
     data.gsub!(/(<img[^>]+)(?<!\/)>/, '\1 />')
 
@@ -448,17 +438,17 @@ class HTMLToConfluenceParser
       data = validated_data.gsub('&amp;_', '&')
     rescue Nokogiri::XML::SyntaxError => e
     end
-    
+
     data
   end
-  
+
   # Return the textile after processing
   def to_wiki_markup
     fix_textile_whitespace!(result.join).gsub(/\n(\*|#)+\s*\n(\*|#)+/) do |match|
       "\n#{match.split("\n").last.squeeze(' ')}"
     end
   end
-  
+
   def fix_textile_whitespace!(output)
     # fixes multiple blank lines, blockquote indicator followed by blank lines, and trailing whitespace after quicktags
     # modifies input string and also returns it
@@ -474,14 +464,13 @@ class HTMLToConfluenceParser
     output.strip!
     return output
   end
-  
-  
+
   def feed(data)
     stream = StringIO.new(preprocess("<div>#{data}</div>"))
-    
+
     REXML::Document.parse_stream(stream, self)
   end
-  
+
   def tag_start(name, attributes = {})
     #puts "<p>Start #{name}</p>"
     @stack.push(name)
@@ -489,7 +478,7 @@ class HTMLToConfluenceParser
       self.send("start_#{name}", attributes)
     end
   end
-  
+
   def tag_end(name)
     #puts "<p>End #{name}</p>"
     if self.respond_to?("end_#{name}")
@@ -497,15 +486,15 @@ class HTMLToConfluenceParser
     end
     @stack.pop
   end
-  
+
   def text(string)
     handle_data(string)
   end
-  
+
   def comment(comment)
     # Comments are ignored.
   end
-  
+
   def cdata(data)
     # CDATA is ignored.
   end

--- a/spec/html2confluence_spec.rb
+++ b/spec/html2confluence_spec.rb
@@ -1,259 +1,312 @@
 # encoding: utf-8
 $LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 require 'html2confluence'
-#require 'redcloth'
 
 describe HTMLToConfluenceParser, "when converting html to textile" do
-  
-  before :all do
-    html = <<-END
-    <div>
-      
-      Some text inside a div<br/>with two lines
-      <h1 class="story.title entry-title" id="post-312">
-      <img src="path_to_image.png" alt="Converting HTML to Textile with Ruby" />
-        <a href="http://jystewart.net/process/2007/11/converting-html-to-textile-with-ruby/" rel="bookmark">Converting HTML to Textile with Ruby</a>
-      </h1>
-      
-      <div class="note">A note</div><div class="note">Followed by another note</div>
-    
-      <p>
-        <span>23 November 2007</span> 
-        (<abbr class="updated" title="2007-11-23T19:51:54+00:00">7:51 pm</abbr>)
-      </p>
-        
-      <p class='test'>
-        By <span class="author vcard fn">James Stewart</span> <br />filed under: 
-          <a href="http://jystewart.net/process/category/snippets/" title="View all posts in Snippets" rel="category tag">Snippets</a>
-          <br />tagged: <a href="http://jystewart.net/process/tag/content-management/" rel="tag">content management</a>,
-          <a href="http://jystewart.net/process/tag/conversion/" rel="tag">conversion</a>,
-          <a href="http://jystewart.net/process/tag/html/" rel="tag">html</a>,
-          <a href="http://jystewart.net/process/tag/python/" rel="tag">Python</a>,
-          <a href="http://jystewart.net/process/tag/ruby/" rel="tag">ruby</a>,
-          <a href="http://jystewart.net/process/tag/textile/" rel="tag">textile</a>
-      </p>
-      
-      <p>test paragraph without id or class attributes</p>
-      
-      <p>test paragraph without closing tag</p>
-      
-      <p>Break not closed<br> at all</p>
-      
-      <li>test<strong> invalid </strong>list item 1</li>
-      <li>test invalid list item 2</li>
-      
-      <ol>
-        <li>test 1</li>
-        <li>test 2<br/>with a line break in the middle</li>
-        <li>test 3</li>
-        <li> <br/></li>
-      </ol>
-      
-      x&gt; y
-      
-      <blockquote>
-        <p>paragraph inside a blockquote</p>
-        <p>another paragraph inside a blockquote</p>
-      </blockquote>
-      
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-        Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure 
-        dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non 
-        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
-      <table cellpadding="3" style="color:red;" summary="a table with a caption">
-        <caption>table caption</caption>
-        <tr>
-          <th>heading 1</th>
-          <th>heading 2</th>
-        </tr>
-        <tr>
-          <td>value 1</td>
-          <td>value 2</td>
-        </tr>
-      </table>
-      
-      Hughes &amp; Hughes
-      
-      Something &amp; something else and <span rel="test">a useless span</span>
-      
-      Some text before a table<table summary="a table without a caption">
-        <tr>
-          <th>heading 1</th>
-          <th>heading 2</th>
-        </tr>
-        <tr>
-          <td>value 1</td>
-          <td>value 2</td>
-        </tr>
-      </table>
-      
-      <p>
-        <strong>Please apply online at:<br /></strong><a href="http://www.something.co.uk/careers">www.something.co.uk/careers</a></p>
-      
-      <p>test <strong><em>test emphasised bold text</em> </strong>test
-      An ordinal number - 1<sup>st </sup>
-      </p>
+  context "in a large html document" do
+    before :all do
+      html = <<-END
+      <div>
 
-      <div class="feedback">
-        Leave some feedback...<br/>
-        <script src="http://feeds.feedburner.com/~s/jystewart/iLiN?i=http://jystewart.net/process/2007/11/converting-html-to-textile-with-ruby/" type="text/javascript" charset="utf-8"></script>
+        Some text inside a div<br/>with two lines
+        <h1 class="story.title entry-title" id="post-312">
+        <img src="path_to_image.png" alt="Converting HTML to Textile with Ruby" />
+          <a href="http://jystewart.net/process/2007/11/converting-html-to-textile-with-ruby/" rel="bookmark">Converting HTML to Textile with Ruby</a>
+        </h1>
+
+        <div class="note">A note</div><div class="note">Followed by another note</div>
+
+        <p>
+          <span>23 November 2007</span>
+          (<abbr class="updated" title="2007-11-23T19:51:54+00:00">7:51 pm</abbr>)
+        </p>
+
+        <p class='test'>
+          By <span class="author vcard fn">James Stewart</span> <br />filed under:
+            <a href="http://jystewart.net/process/category/snippets/" title="View all posts in Snippets" rel="category tag">Snippets</a>
+            <br />tagged: <a href="http://jystewart.net/process/tag/content-management/" rel="tag">content management</a>,
+            <a href="http://jystewart.net/process/tag/conversion/" rel="tag">conversion</a>,
+            <a href="http://jystewart.net/process/tag/html/" rel="tag">html</a>,
+            <a href="http://jystewart.net/process/tag/python/" rel="tag">Python</a>,
+            <a href="http://jystewart.net/process/tag/ruby/" rel="tag">ruby</a>,
+            <a href="http://jystewart.net/process/tag/textile/" rel="tag">textile</a>
+        </p>
+
+        <p>test paragraph without id or class attributes</p>
+
+        <p>test paragraph without closing tag</p>
+
+        <p>Break not closed<br> at all</p>
+
+        <li>test<strong> invalid </strong>list item 1</li>
+        <li>test invalid list item 2</li>
+
+        <ol>
+          <li>test 1</li>
+          <li>test 2<br/>with a line break in the middle</li>
+          <li>test 3</li>
+          <li> <br/></li>
+        </ol>
+
+        x&gt; y
+
+        <blockquote>
+          <p>paragraph inside a blockquote</p>
+          <p>another paragraph inside a blockquote</p>
+        </blockquote>
+
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+          dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+          proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+        <table cellpadding="3" style="color:red;" summary="a table with a caption">
+          <caption>table caption</caption>
+          <tr>
+            <th>heading 1</th>
+            <th>heading 2</th>
+          </tr>
+          <tr>
+            <td>value 1</td>
+            <td>value 2</td>
+          </tr>
+        </table>
+
+        Hughes &amp; Hughes
+
+        Something &amp; something else and <span rel="test">a useless span</span>
+
+        Some text before a table<table summary="a table without a caption">
+          <tr>
+            <th>heading 1</th>
+            <th>heading 2</th>
+          </tr>
+          <tr>
+            <td>value 1</td>
+            <td>value 2</td>
+          </tr>
+        </table>
+
+        <p>
+          <strong>Please apply online at:<br /></strong><a href="http://www.something.co.uk/careers">www.something.co.uk/careers</a></p>
+
+        <p>test <strong><em>test emphasised bold text</em> </strong>test
+        An ordinal number - 1<sup>st </sup>
+        </p>
+
+        <div class="feedback">
+          Leave some feedback...<br/>
+          <script src="http://feeds.feedburner.com/~s/jystewart/iLiN?i=http://jystewart.net/process/2007/11/converting-html-to-textile-with-ruby/" type="text/javascript" charset="utf-8"></script>
+        </div>
+
+        <p>&nbsp;<br/></p>
+        <blockquote>&nbsp;<br/></blockquote>
+        <strong>more bold text</strong><strong><br /></strong>
+
+        <p>Some text with <u>underlining</u> is here.</p>
+
+        <p>Æïœü</p>
+
+        <code>some_good_code</code>
+
+        &copy; Copyright statement, let's see what happens to this&#8230; &euro; 100
+
+        An unknown named entity reference - &unknownref;
+
+        <strike>strike 1</strike>
+        <del>strike 2</del>
+
+        # Not a list
+        * Not a list
+        - Not a list
+        *Not bold*
+        _Not a emph_
+        {Not curly}
+        |Not table
       </div>
-      
-      <p>&nbsp;<br/></p>
-      <blockquote>&nbsp;<br/></blockquote>
-      <strong>more bold text</strong><strong><br /></strong>
+      END
+      parser = HTMLToConfluenceParser.new
+      parser.feed(html)
+      @textile = parser.to_wiki_markup
+    end
 
-      <p>Some text with <u>underlining</u> is here.</p>
+    it "should convert heading tags" do
+      expect(@textile).to match(/^h1(\([^\)]+\))?\./)
+    end
 
-      <p>Æïœü</p>
+    it "should convert underline tags" do
+      expect(@textile).to include("text with +underlining+ is here")
+    end
 
-      <code>some_good_code</code>
+    it "should not explicitly markup paragraphs unnecessarily" do
+      expect(@textile).to_not include("p. test paragraph without id or class attributes")
+    end
 
-      &copy; Copyright statement, let's see what happens to this&#8230; &euro; 100
+    it "should treat divs as block level elements, but ignore any attributes (effectively converting them to paragraphs)" do
+      expect(@textile).to include("\n\nA note\n\nFollowed by another note\n\n")
+    end
 
-      An unknown named entity reference - &unknownref; 
+    it "should not convert pointless spans to textile (i.e. without supported attributes)" do
+      expect(@textile).to_not include("%a useless span%")
+    end
 
-      <strike>strike 1</strike>
-      <del>strike 2</del>
+    it "should convert class and id attributes" do
+      # We don't convert classes. expect(@textile).to include("h1(story.title entry-title#post-312).")
+    end
 
-      # Not a list
-      * Not a list
-      - Not a list
-      *Not bold*
-      _Not a emph_
-      {Not curly}
-      |Not table
-    </div>
+    it "should convert tables" do
+      expect(@textile).to include("\n\n||heading 1 ||heading 2 || \n|value 1 |value 2 | \n")
+    end
+
+    it "should convert tables with text immediately preceding the opening table tag" do
+      expect(@textile).to include("Some text before a table\n\n||heading 1 ||heading 2 || \n|value 1 |value 2 | \n")
+    end
+
+    it "should respect line breaks within block level elements" do
+      expect(@textile).to include("\n# test 1 \n# test 2\nwith a line break in the middle")
+    end
+
+    it "should handle paragraphs nested within blockquote" do
+      expect(@textile).to include("{quote}\n\nparagraph inside a blockquote\n\nanother paragraph inside a blockquote\n\n{quote}")
+    end
+
+    it "should retain leading and trailing whitespace within inline elements" do
+      expect(@textile).to include("test *invalid* list item 1")
+    end
+
+    it "should respect trailing line break tags within other elements" do
+      expect(@textile).to include("*Please apply online at:*\n[www.something.co.uk/careers|http://www.something.co.uk/careers]")
+    end
+
+    it "should handle nested inline elements" do
+      expect(@textile).to include(" *_test emphasised bold text_* test")
+    end
+
+    it "should remove empty quicktags before returning" do
+      expect(@textile).to_not include("*more bold text* *\n*")
+    end
+
+    it "should remove unsupported elements (e.g. script)" do
+      expect(@textile).to_not include('script')
+    end
+
+    it "should remove unsupported attributes (i.e. everything but class and id)" do
+      expect(@textile).to_not include('summary')
+      expect(@textile).to_not include('a table with a caption')
+      expect(@textile).to_not include('style')
+      expect(@textile).to_not include('color:red;')
+    end
+
+    it "should clean up multiple blank lines created by tolerant parsing before returning" do
+      expect(@textile).to_not match(/(\n\n\s*){2,}/)
+    end
+
+    it "should keep entity references" do
+      expect(@textile).to include("&copy;")
+    end
+
+    it "should output unknown named entity references" do
+      expect(@textile).to include("&unknownref;")
+    end
+
+    it "should convert numerical entity references to a utf-8 character" do
+      expect(@textile).to include("…")
+    end
+
+    it "should ignore entities that are already converted" do
+      expect(@textile).to include("Æïœü")
+    end
+
+    it "should ignore ampersands that are not part of an entity reference" do
+      expect(@textile).to include("Hughes & Hughes")
+    end
+
+    it "should retain whitespace surrounding entity references" do
+      expect(@textile).to include("… &euro; 100")
+      expect(@textile).to include("Something & something")
+    end
+
+    it "should escape special characters" do
+      # This test currently fails. We would like it to pass, but only by escaping
+      # characters that would otherwise be mistaken for markup. It should not
+      # escape every instance of these characters.
+      pending 'only escape correct characters'
+      expect(@textile).to include("\\# Not a list")
+      expect(@textile).to include("\\* Not a list")
+      expect(@textile).to include("\\- Not a list")
+      expect(@textile).to include("\\*Not bold\\*")
+      expect(@textile).to include("\\_Not a emph\\_")
+      expect(@textile).to include("\\{Not curly\\}")
+      expect(@textile).to include("\\|Not table")
+    end
+
+    it "should support strikethrough" do
+      expect(@textile).to include("-strike 1-")
+      expect(@textile).to include("-strike 2-")
+    end
+
+    it "should transform code" do
+      expect(@textile).to include("{code}some_good_code{code}")
+    end
+  end
+
+  it "should convert ending blockquotes" do
+    html = <<-END
+    <blockquote>
+      <pre>
+      </pre>
+      <div>
+        <div>
+          <pre>
+          </pre>
+        </div>
+      </div>
+    </blockquote>
     END
+
     parser = HTMLToConfluenceParser.new
     parser.feed(html)
     @textile = parser.to_wiki_markup
-    #puts @textile
-    #puts RedCloth.new(@textile).to_html
+
+    expect(@textile).to eq("{quote}\n{noformat}\n\n{noformat} \n\n{noformat}\n\n{noformat} \n\n{quote}")
   end
 
-  it "should convert heading tags" do
-    expect(@textile).to match(/^h1(\([^\)]+\))?\./)
-  end
-  
-  it "should convert paragraph tags" do
-    # We don't include paragraph classes expect(@textile).to match(/^p(\([^\)]+\))?\./)
-  end
-  
-  it "should convert underline tags" do
-    expect(@textile).to include("text with +underlining+ is here")
-  end
-  
-  it "should not explicitly markup paragraphs unnecessarily" do
-    expect(@textile).to_not include("p. test paragraph without id or class attributes")
-  end
-  
-  it "should treat divs as block level elements, but ignore any attributes (effectively converting them to paragraphs)" do
-    expect(@textile).to include("\n\nA note\n\nFollowed by another note\n\n")
-  end
-  
-  it "should not convert pointless spans to textile (i.e. without supported attributes)" do
-    expect(@textile).to_not include("%a useless span%")
+  it "should convert ending blockquotes without a leading pre" do
+    html = <<-END
+    <blockquote>
+      <div>
+        <div>
+          <pre>
+          </pre>
+        </div>
+      </div>
+    </blockquote>
+    END
+
+    parser = HTMLToConfluenceParser.new
+    parser.feed(html)
+    @textile = parser.to_wiki_markup
+
+    expect(@textile).to eq("{quote}\n\n{noformat}\n\n{noformat} \n\n{quote}")
   end
 
-  it "should convert class and id attributes" do
-    # We don't convert classes. expect(@textile).to include("h1(story.title entry-title#post-312).")
-  end
-  
-  it "should convert tables" do
-    expect(@textile).to include("\n\n||heading 1 ||heading 2 || \n|value 1 |value 2 | \n")
-  end
-  
-  it "should convert tables with text immediately preceding the opening table tag" do
-    expect(@textile).to include("Some text before a table\n\n||heading 1 ||heading 2 || \n|value 1 |value 2 | \n")
-  end
-  
-  it "should respect line breaks within block level elements" do
-    expect(@textile).to include("\n# test 1 \n# test 2\nwith a line break in the middle")
-  end
-  
-  it "should handle paragraphs nested within blockquote" do
-    expect(@textile).to include("{quote}\n\nparagraph inside a blockquote\n\nanother paragraph inside a blockquote\n\n{quote}")
-  end
-  
-  it "should retain leading and trailing whitespace within inline elements" do
-    expect(@textile).to include("test *invalid* list item 1")
-  end
-  
-  it "should respect trailing line break tags within other elements" do
-    expect(@textile).to include("*Please apply online at:*\n[www.something.co.uk/careers|http://www.something.co.uk/careers]")
-  end
-  
-  it "should handle nested inline elements" do
-    expect(@textile).to include(" *_test emphasised bold text_* test")
-  end
-  
-  it "should remove empty quicktags before returning" do
-    expect(@textile).to_not include("*more bold text* *\n*")
-  end  
-  
-  it "should remove unsupported elements (e.g. script)" do
-    expect(@textile).to_not include('script')
-  end
-  
-  it "should remove unsupported attributes (i.e. everything but class and id)" do
-    expect(@textile).to_not include('summary')
-    expect(@textile).to_not include('a table with a caption')
-    expect(@textile).to_not include('style')
-    expect(@textile).to_not include('color:red;')
-  end
-  
-  it "should clean up multiple blank lines created by tolerant parsing before returning" do
-    expect(@textile).to_not match(/(\n\n\s*){2,}/)
-  end
-  
-  it "should keep entity references" do
-    expect(@textile).to include("&copy;")
-  end
-  
-  it "should output unknown named entity references" do
-    expect(@textile).to include("&unknownref;")
-  end  
-  
-  it "should convert numerical entity references to a utf-8 character" do
-    expect(@textile).to include("…")
-  end
+  it "should convert ending blockquotes without a nested pre" do
+    html = <<-END
+    <blockquote>
+      <pre>
+      </pre>
+      <div>
+        <div>
+        </div>
+      </div>
+    </blockquote>
+    END
 
-  it "should ignore entities that are already converted" do
-    expect(@textile).to include("Æïœü")
-  end
-  
-  it "should ignore ampersands that are not part of an entity reference" do
-    expect(@textile).to include("Hughes & Hughes")
-  end
-  
-  it "should retain whitespace surrounding entity references" do
-    expect(@textile).to include("… &euro; 100")
-    expect(@textile).to include("Something & something")
-  end
-  
-  it "should escape special characters" do
-    # This test currently fails. We would like it to pass, but only by escaping
-    # characters that would otherwise be mistaken for markup. It should not
-    # escape every instance of these characters.
-    pending 'only escape correct characters'
-    expect(@textile).to include("\\# Not a list")
-    expect(@textile).to include("\\* Not a list")
-    expect(@textile).to include("\\- Not a list")
-    expect(@textile).to include("\\*Not bold\\*")
-    expect(@textile).to include("\\_Not a emph\\_")
-    expect(@textile).to include("\\{Not curly\\}")
-    expect(@textile).to include("\\|Not table")
-  end
-  
-  it "should support strikethrough" do
-    expect(@textile).to include("-strike 1-")
-    expect(@textile).to include("-strike 2-")
-  end
+    parser = HTMLToConfluenceParser.new
+    parser.feed(html)
+    @textile = parser.to_wiki_markup
 
-  it "should transform code" do
-    expect(@textile).to include("{code}some_good_code{code}")
+    expect(@textile).to eq("{quote}\n{noformat}\n\n{noformat} \n\n{quote}")
   end
 end


### PR DESCRIPTION
Okay, so this one was fun.  Buckle your seat belt, we're going for a ride!

Here is the error:
https://sentry.io/aha-labs-inc/aha-production/issues/443547999/

Here is the html we were trying to parse:
`
    <blockquote>
      <pre>
      </pre>
      <div>
        <div>
          <pre>
          </pre>
        </div>
      </div>
    </blockquote>
`

When parsed, we'd end up here:
```
[2] pry(#<HTMLToConfluenceParser>)> self
=> #<HTMLToConfluenceParser:0x00007fbc729fac50
 @data_stack=[],
 @last_write="",
 @list_stack=[],
 @output="",
 @preserveWhitespace=false,
 @result=["\n\n", "", " ", "{noformat}\n", "\n      ", "{noformat}", " ", "\n\n", "", "\n\n", "", "{noformat}\n", "\n          ", "{noformat}", " ", "\n\n", "", "\n\n", ""],
 @stack=["div", "blockquote"],
 @tableHeaderRow=false>
```
To break this down:
` @data_stack=[],` is our current reference in the stack of items
` @stack=["div", "blockquote"],` is our current stack (we wrap everything in a `div`)
`@result` is the current output


In this state, we'd then ask to see if our current input contained a `bq.` https://github.com/aha-app/html2confluence/compare/APP-6796-Parsing-BlockQuotes?expand=1#diff-df273a0f4e001ef74b9080a2ac7405c0L353 but since our current `data_stack` is empty, we get a `nil`, which we then call `detect` on throwing the error.

So, rather than support `bq.`, I'm proposing we instead use `{quote}` to do this.  If you use the editor in Jira to create a blockquote, it also uses this syntax, rather than `bq.` so I think we're safe to migrate away from this syntax.

Reference: https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all