### PR TITLE
support input type checkbox

### DIFF
--- a/example.rb
+++ b/example.rb
@@ -12,6 +12,11 @@ first_block = <<END
   </p>
 
   <p>
+    <input type="checkbox">
+    <input type="checkbox" checked="">
+  </p>
+
+  <p>
     By <span class="author vcard fn">James Stewart</span>
     <br />filed under:
       <a href="http://jystewart.net/process/category/snippets/" title="View all posts in Snippets" rel="category tag">Snippets</a>

--- a/lib/html2confluence.rb
+++ b/lib/html2confluence.rb
@@ -239,6 +239,16 @@ class HTMLToConfluenceParser
     end
   end
 
+  def start_input(attrs)
+    if attrs['type'] == "checkbox"
+      if attrs['checked']
+        write("(/) ")
+      else
+        write("(x) ")
+      end
+    end
+  end
+
   # Jira doesn't like it when there's space padding around images in links, like thumbnails.
   # By checking to see if the link content is a single image, we can strip those out and preserve the link function
   def link_content_filtering_out_images(content)

--- a/spec/checkbox_examples_spec.rb
+++ b/spec/checkbox_examples_spec.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
+require 'html2confluence'
+
+describe HTMLToConfluenceParser, "when running checkbox examples" do
+
+  it "should match checkboxes" do
+    html = <<-END
+    <div class="wiki text common-markdown"><ul class="markdown-checkbox-list">
+    <li><label><input type="checkbox" data-position="0" checked="">Example 1</label></li>
+    <li><label><input type="checkbox" data-position="1" checked="">Example 2</label></li>
+    <li><label><input type="checkbox" data-position="2">Example 3</label></li>
+    <li><label><input type="checkbox" data-position="3" checked="">Example 4</label></li>
+    <li><label><input type="checkbox" data-position="4">Example 5</label></li>
+    </ul>
+    </div>
+    END
+
+    markup = <<-END
+* (/) Example 1
+* (/) Example 2
+* (x) Example 3
+* (/) Example 4
+* (x) Example 5
+    END
+
+    parser = HTMLToConfluenceParser.new
+    parser.feed(html)
+    expect(parser.to_wiki_markup.strip).to include(markup.strip)
+  end
+  
+end


### PR DESCRIPTION
For our YouTrack to JIRA migration we wanted to keep the checkbox information which we used to mark done sub-tasks. 

There is not direct checkbox replacement, but i used the suggestions from here: https://community.atlassian.com/t5/Jira-questions/Adding-checkboxes-into-issue-description/qaq-p/1902

Better to have the information in a static way than loosing it altogether.